### PR TITLE
Fixed cf-stat card link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@
 <p>&nbsp;<img align="center" src="https://github-readme-stats.vercel.app/api?username=md-asraful-islam-subbir&show_icons=true&locale=en" alt="md-asraful-islam-subbir" /></p>
 
 <p><img align="center" src="https://github-readme-streak-stats.herokuapp.com/?user=md-asraful-islam-subbir&" alt="md-asraful-islam-subbir" /></p>
-![](https://raw.githubusercontent.com/Md-Asraful-Islam-Subbir/cf-stats/main/output/light_card.svg#gh-dark-mode-only)
-![](https://raw.githubusercontent.com/Md-Asraful-Islam-Subbir/cf-stats/main/output/light_card.svg)
+
+![](https://raw.githubusercontent.com/Md-Asraful-Islam-Subbir/Cf_template/main/output/light_card.svg)


### PR DESCRIPTION
you named the repo as `Cf_template` so, your link is different from the example link in the readme of the cf stats project.